### PR TITLE
Use getopts for command line arguments

### DIFF
--- a/bin/burncdi
+++ b/bin/burncdi
@@ -62,7 +62,7 @@ while getopts "fc:" opt; do
     esac
 done
 
-CDIIMG="${@:$OPTIND:1}"
+CDIIMG=${@:$OPTIND:1}
 
 function show_help {
     if [ $# -gt 0 ] ; then
@@ -97,13 +97,7 @@ if [ ! -e "$DEVICE" ] ; then
         show_help "ERROR: Couldn't open CD-R: $DEVICE"
 fi
 
-EXT_DIR="ext_$(basename $CDIIMG)"
-if [ -e $EXT_DIR ] ; then
-    echo "ERROR: Couldn't unpack to '$EXT_DIR' - File exists"
-    exit 2
-fi
-
-mkdir ${EXT_DIR}
+EXT_DIR=$(mktemp -d)
 if [ -d ${EXT_DIR} ] ; then 
     cdirip "${CDIIMG}" "${EXT_DIR}" -cdrecord || \
     show_help "ERROR: ${EXT_DIR} dosn't exist!"

--- a/bin/burncdi
+++ b/bin/burncdi
@@ -62,7 +62,7 @@ while getopts "fc:" opt; do
     esac
 done
 
-CDIIMG=${@:$OPTIND:1}
+CDIIMG="${@:$OPTIND:1}"
 
 function show_help {
     if [ $# -gt 0 ] ; then

--- a/bin/burncdi
+++ b/bin/burncdi
@@ -41,15 +41,28 @@ else
     BURNBIN=wodim
 fi
 
-if [ "$1" == "-f" ] ; then
-        OVERBURN="-overburn"
-        shift
-else
-        OVERBURN=""
-fi
-
-CDIIMG="$1"
+OVERBURN=""
 DEVICE="/dev/cdrw"
+while getopts "fc:" opt; do
+    case $opt in
+        c)
+            DEVICE="$OPTARG"
+            ;;
+        f)
+            OVERBURN="-overburn"
+            ;;
+        \?)
+            echo "Unknown options -$OPTARG."
+            exit 1
+            ;;
+	:)
+            echo "-$OPTARG requires argument."
+            exit 1
+            ;;
+    esac
+done
+
+CDIIMG="${@:$OPTIND:1}"
 
 function show_help {
     if [ $# -gt 0 ] ; then
@@ -59,9 +72,10 @@ function show_help {
     fi
     echo "BurnCDI by milksheik, improved by Nold"
     echo "Usage:"
-    echo "       $0 [-f] <CDI-File>"
+    echo "       $0 [-f] [-c <CDRW-DRIVE>] <CDI-File>"
     echo
     echo "       -f | Force burning of Image & enable overburning"
+    echo "       -c | Path to CD writer if not /dev/cdrw"
     exit 1
 }
 


### PR DESCRIPTION
- Allow passing path to cddrive as argument.
- Use getopts to handle arguments.
- Basic error handling for arugments.
- Use mktemp for more robust temp directory than basename. Makes life easier than escaping scene file names.

Tested on Fedora 27.